### PR TITLE
Rate-limiter support!

### DIFF
--- a/binancechain/httpclient.py
+++ b/binancechain/httpclient.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import aiohttp
 
 from .exceptions import BinanceChainException
+from .ratelimit import RateLimiter
 
 log = logging.getLogger(__name__)
 
@@ -22,17 +23,26 @@ TESTNET_URL = "https://testnet-dex.binance.org"
 class HTTPClient:
     """ Binance Chain HTTP API Client """
 
-    def __init__(self, testnet: bool = True, api_version: str = "v1", url=None):
+    def __init__(
+        self,
+        testnet: bool = True,
+        api_version: str = "v1",
+        url=None,
+        rate_limit: bool = False,
+    ):
         """
         :param testnet: Use testnet instead of mainnet
         :param api_version: The API version to use
         :param session: An optional HTTP session to use
+        :param rate_limit: Enable automatic rate-limiting
         """
         if not url:
             url = TESTNET_URL if testnet else MAINNET_URL
         self._server = f"{url}/api/{api_version}/"
         self._session: aiohttp.ClientSession = None
         self._testnet = testnet
+        if rate_limit:
+            self._rate_limiter = RateLimiter()
 
     def __del__(self):
         if self._session:  # pragma: nocover
@@ -43,6 +53,8 @@ class HTTPClient:
         if self._session:
             await self._session.close()
             self._session = None
+        if self._rate_limiter:
+            self._rate_limiter.close()
 
     async def _request(self, method: str, path: str, **kwargs):
         """
@@ -82,6 +94,8 @@ class HTTPClient:
         Destination: Validator node.
         Rate Limit: 1 request per IP per second.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("time", 1)
         return await self.get_request("time")
 
     async def get_node_info(self) -> dict:
@@ -92,6 +106,8 @@ class HTTPClient:
         Destination: Validator node.
         Rate Limit: 1 request per IP per second.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("node-info", 1)
         return await self.get_request("node-info")
 
     async def get_validators(self) -> dict:
@@ -102,6 +118,8 @@ class HTTPClient:
         Destination: Witness node.
         Rate Limit: 10 requests per IP per second.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("validators", 10)
         return await self.get_request("validators")
 
     async def get_peers(self) -> List[dict]:
@@ -112,6 +130,8 @@ class HTTPClient:
         Destination: Witness node.
         Rate Limit: 1 request per IP per second.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("peers", 1)
         return await self.get_request("peers")
 
     async def get_account(self, address: str) -> dict:
@@ -124,6 +144,8 @@ class HTTPClient:
 
         :param address: The account address to query
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("account", 5)
         return await self.get_request(f"account/{address}")
 
     async def get_account_sequence(self, address: str) -> dict:
@@ -137,6 +159,8 @@ class HTTPClient:
 
         :param address: The account address to query.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("account", 5)
         return await self.get_request(f"account/{address}/sequence")
 
     async def get_transaction(self, hash: str) -> dict:
@@ -150,6 +174,8 @@ class HTTPClient:
 
         :param hash: The transaction hash to query
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("tx", 10)
         return await self.get_request(f"tx/{hash}")
 
     async def get_token_list(self) -> List[dict]:
@@ -160,6 +186,8 @@ class HTTPClient:
         Destination: Witness node.
         Rate Limit: 1 request per IP per second.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("tokens", 1)
         return await self.get_request("tokens")
 
     async def get_markets(self, limit: int = 500, offset: int = 0) -> List[dict]:
@@ -173,6 +201,8 @@ class HTTPClient:
         :param limit: default 500; max 1000.
         :param offset: start with 0; default 0.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("markets", 1)
         return await self.get_request(
             "markets", params={"limit": limit, "offset": offset}
         )
@@ -185,6 +215,8 @@ class HTTPClient:
         Destination: Witness node.
         Rate Limit: 1 request per IP per second.
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("fees", 1)
         return await self.get_request("fees")
 
     async def get_depth(self, symbol: str, limit: int = 100) -> Dict[str, list]:
@@ -199,6 +231,8 @@ class HTTPClient:
         :param symbol: Market pair symbol, e.g. NNB-0AD_BNB
         :param limit: The limit of results. Allowed limits: [5, 10, 20, 50, 100, 500, 1000]
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("depth", 10)
         return await self.get_request(
             "depth", params={"symbol": symbol, "limit": limit}
         )
@@ -215,6 +249,8 @@ class HTTPClient:
         :param sync: Synchronous broadcast (wait for DeliverTx)?
         :param body: Hex-encoded transaction
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("broadcast", 5)
         return await self.post_request(
             "broadcast", data=body, headers={"Content-Type": "text/plain"}
         )
@@ -245,6 +281,8 @@ class HTTPClient:
         :param start: start time in Milliseconds
         :param end: end time in Milliseconds
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("klines", 10)
         params = {"symbol": symbol, "interval": interval, "limit": limit}
         if start is not None:
             params["startTime"] = int(start)
@@ -285,9 +323,9 @@ class HTTPClient:
         :param total: total number required, 0 for not required and 1 for
             required; default not required, return total=-1 in response
         """
-        params = {
-            "address": address,
-        }
+        if self._rate_limiter:
+            await self._rate_limiter.limit("orders", 5)
+        params = {"address": address}
         if end is not None:
             params['end'] = int(end)
         if limit is not None:
@@ -327,6 +365,8 @@ class HTTPClient:
         :param total: total number required, 0 for not required and 1 for
             required; default not required, return total=-1 in response
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("orders", 5)
         params = {"address": address}
         if limit is not None:
             params["limit"] = limit
@@ -347,6 +387,8 @@ class HTTPClient:
 
         :param id: order id
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("orders", 5)
         return await self.get_request(f"orders/{id}")
 
     async def get_ticker(self, symbol: str = None) -> List[dict]:
@@ -358,6 +400,8 @@ class HTTPClient:
 
         :param symbol: symbol
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("ticker", 5)
         params = {}
         if symbol:
             params["symbol"] = symbol
@@ -401,6 +445,8 @@ class HTTPClient:
         :param total: total number required, 0 for not required and 1 for
             required; default not required, return total=-1 in response
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("trades", 5)
         params: Dict[Any, Any] = {}
         if address is not None:
             params["address"] = address
@@ -455,6 +501,8 @@ class HTTPClient:
         :param total: total number required, 0 for not required and 1 for
             required; default not required, return total=-1 in response
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("block-exchange-fee", 5)
         params: Dict[Any, Any] = {}
         if address is not None:
             params["address"] = address
@@ -504,6 +552,8 @@ class HTTPClient:
             NEW_ORDER,ISSUE_TOKEN,BURN_TOKEN,LIST_TOKEN,CANCEL_ORDER,FREEZE_TOKEN,
             UN_FREEZE_TOKEN,TRANSFER,PROPOSAL,VOTE,MINT,DEPOSIT]
         """
+        if self._rate_limiter:
+            await self._rate_limiter.limit("transactions", 1)
         params: Dict[Any, Any] = {"address": address}
         if height is not None:
             params["blockHeight"] = height

--- a/binancechain/ratelimit.py
+++ b/binancechain/ratelimit.py
@@ -1,0 +1,46 @@
+# Copyright 2019, Luke Macken, Kim Bui, and the binance-chain-python contributors
+# SPDX-License-Identifier: MIT
+
+import asyncio
+
+from typing import Dict, Tuple
+
+
+class RateLimiter:
+    """A rate-limiter that manages a token bucket for each namespace"""
+
+    def __init__(self, period: int = 1):
+        """
+        :param period: How often this rate limiter will wake up to fill
+        the token buckets. Defaults to once a second.
+        """
+        self.buckets: Dict[str, Tuple[asyncio.Queue, int]] = {}
+        self.period = period
+        self.task = None
+
+    def close(self):
+        if self.task:
+            self.task.cancel()
+
+    async def token_manager(self):
+        """Fills each of the token buckets at `self.period` intervals."""
+        while True:
+            await asyncio.sleep(self.period)
+            for queue, num in self.buckets.values():
+                for i in range(num - queue.qsize()):
+                    queue.put_nowait(1)
+
+    async def limit(self, namespace, num):
+        """Blocks for a given `namespace`, rate-limiting appropriately"""
+        if namespace not in self.buckets:
+            queue = asyncio.Queue(num)
+            self.buckets[namespace] = (queue, num)
+            for _ in range(num):
+                queue.put_nowait(1)
+            if not self.task:
+                self.task = asyncio.ensure_future(self.token_manager())
+                # Let the manager begin it's sleep cycle
+                await asyncio.sleep(0.001)
+        else:
+            queue = self.buckets[namespace][0]
+        await queue.get()

--- a/test/test_ratelimit.py
+++ b/test/test_ratelimit.py
@@ -1,0 +1,26 @@
+import asyncio
+import pytest
+
+from binancechain import HTTPClient
+
+
+@pytest.mark.asyncio
+async def test_ratelimiter():
+    """
+    Make 10 `time` requests concurrently and ensure they are not rate-limited
+    """
+    client = HTTPClient(testnet=True, rate_limit=True)
+    futures = []
+    for _ in range(100):
+        futures.append(asyncio.ensure_future(client.get_time()))
+
+    results = await asyncio.gather(*futures)
+    print(results)
+    assert results
+    for result in results:
+        print(result)
+        if 'message' in result:
+            assert result['message'] != 'API rate limit exceeded'
+        assert 'block_time' in result
+
+    await client.close()


### PR DESCRIPTION
This adds an optional `rate_limit` option to the `HTTPClient` that enables a per-endpoint tokenbucket rate-limiter, with a single "manager" coroutine to refill the buckets every second.